### PR TITLE
Rebuild resume page to match provided layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,222 +3,78 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>李雷 · 前端工程师</title>
+  <title>张康乐 · 个人简介</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Noto+Sans+SC:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="fixed-top shadow-sm bg-body-tertiary bg-opacity-75 backdrop-blur">
-    <nav class="navbar navbar-expand-lg navbar-light" aria-label="Primary navigation">
-      <div class="container">
-        <a class="navbar-brand fw-semibold" href="#top">Li Lei</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#primaryNav" aria-controls="primaryNav" aria-expanded="false" aria-label="切换导航">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="primaryNav">
-          <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-            <li class="nav-item"><a class="nav-link" href="#about">About</a></li>
-            <li class="nav-item"><a class="nav-link" href="#skills">Skills</a></li>
-            <li class="nav-item"><a class="nav-link" href="#projects">Projects</a></li>
-            <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li>
-          </ul>
+  <div class="resume-wrapper">
+    <aside class="profile-card" aria-labelledby="profile-name">
+      <img
+        src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=400&q=80"
+        alt="张康乐的个人照片"
+        class="avatar"
+        width="200"
+        height="200"
+        loading="lazy"
+      />
+      <h1 id="profile-name">张康乐</h1>
+      <p class="subtitle">2027届毕业生 · 信息工程学院</p>
+      <dl class="profile-data">
+        <div class="data-row">
+          <dt>姓名</dt>
+          <dd>张康乐</dd>
         </div>
-      </div>
-    </nav>
-  </header>
-
-  <main id="top" class="pt-5">
-    <section id="about" class="py-5" aria-labelledby="about-title">
-      <div class="container">
-        <div class="row align-items-center g-4">
-          <div class="col-md-4 text-center">
-            <figure class="m-0">
-              <img src="https://picsum.photos/320" alt="李雷头像" class="img-fluid rounded-circle shadow-sm profile-photo" loading="lazy" width="320" height="320" />
-              <figcaption class="visually-hidden">前端工程师李雷的头像</figcaption>
-            </figure>
-          </div>
-          <div class="col-md-8">
-            <h1 id="about-title" class="fw-bold mb-3">李雷 · 前端工程师</h1>
-            <p class="lead text-secondary">热爱简洁代码与优雅体验的全栈倾向前端开发者。</p>
-            <p>专注于构建性能优、可维护的 Web 应用，擅长将设计转化为灵活的交互界面，并持续关注可访问性与工程效率。</p>
-            <a class="btn btn-primary mt-3" href="#" role="button">下载简历</a>
-          </div>
+        <div class="data-row">
+          <dt>学号</dt>
+          <dd>202330701200</dd>
         </div>
-      </div>
-    </section>
-
-    <section class="py-5 bg-body" aria-label="作品轮播">
-      <div class="container">
-        <div id="showcaseCarousel" class="carousel slide" data-bs-ride="carousel">
-          <div class="carousel-indicators">
-            <button type="button" data-bs-target="#showcaseCarousel" data-bs-slide-to="0" class="active" aria-current="true" aria-label="幻灯片 1"></button>
-            <button type="button" data-bs-target="#showcaseCarousel" data-bs-slide-to="1" aria-label="幻灯片 2"></button>
-            <button type="button" data-bs-target="#showcaseCarousel" data-bs-slide-to="2" aria-label="幻灯片 3"></button>
-          </div>
-          <div class="carousel-inner rounded-4 shadow-sm overflow-hidden">
-            <div class="carousel-item active" data-bs-interval="5000">
-              <img src="https://picsum.photos/seed/interface/1200/500" class="d-block w-100" alt="项目界面展示图" loading="lazy" width="1200" height="500" />
-              <div class="carousel-caption d-none d-md-block">
-                <h5>响应式企业站</h5>
-                <p>为成长型企业打造的跨平台形象网站。</p>
-              </div>
-            </div>
-            <div class="carousel-item" data-bs-interval="5000">
-              <img src="https://picsum.photos/seed/dashboard/1200/500" class="d-block w-100" alt="数据面板展示" loading="lazy" width="1200" height="500" />
-              <div class="carousel-caption d-none d-md-block">
-                <h5>数据分析仪表盘</h5>
-                <p>即时数据可视化与团队协作。</p>
-              </div>
-            </div>
-            <div class="carousel-item" data-bs-interval="5000">
-              <img src="https://picsum.photos/seed/mobile/1200/500" class="d-block w-100" alt="移动端应用界面" loading="lazy" width="1200" height="500" />
-              <div class="carousel-caption d-none d-md-block">
-                <h5>PWA 购物体验</h5>
-                <p>离线可用的渐进式 Web 购物平台。</p>
-              </div>
-            </div>
-          </div>
-          <button class="carousel-control-prev" type="button" data-bs-target="#showcaseCarousel" data-bs-slide="prev" aria-label="上一张">
-            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-          </button>
-          <button class="carousel-control-next" type="button" data-bs-target="#showcaseCarousel" data-bs-slide="next" aria-label="下一张">
-            <span class="carousel-control-next-icon" aria-hidden="true"></span>
-          </button>
+        <div class="data-row">
+          <dt>学院</dt>
+          <dd>信息工程学院</dd>
         </div>
-      </div>
-    </section>
-
-    <section id="skills" class="py-5" aria-labelledby="skills-title">
-      <div class="container">
-        <div class="row align-items-center g-4">
-          <div class="col-lg-4">
-            <h2 id="skills-title" class="fw-semibold">技能栈</h2>
-            <p class="text-secondary mb-0">通过结构化思维与自动化工具，持续提升交付效率。</p>
+        <div class="data-row">
+          <dt>班级</dt>
+          <dd>信息工程学部（2023级）</dd>
+        </div>
+      </dl>
+    </aside>
+    <div class="detail-column">
+      <section class="detail-card" aria-labelledby="summary-title">
+        <h2 id="summary-title">个人简介</h2>
+        <p>湖北中医药大学信息工程学院软件工程专业学生，专注于信息系统培训与实训。</p>
+        <p>推进校企合作项目与智慧校园建设，熟悉 C#、Web 前端框架与数据库应用，关注前沿科技热点趋势。</p>
+        <p>坚信技术创新与医工融合是推动行业进步的关键路径，热衷于用技术解决实际问题。</p>
+      </section>
+      <section class="detail-card" aria-labelledby="info-title">
+        <h2 id="info-title">个人信息</h2>
+        <div class="info-grid">
+          <div class="info-item">
+            <span class="label">籍贯</span>
+            <span class="value">湖南长沙</span>
           </div>
-          <div class="col-lg-8">
-            <ul class="list-inline skill-list mb-0">
-              <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">HTML5</span></li>
-              <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">CSS3</span></li>
-              <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">JavaScript</span></li>
-              <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">Bootstrap</span></li>
-              <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">jQuery</span></li>
-              <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">Git</span></li>
-              <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">REST API</span></li>
-              <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">Accessibility</span></li>
-            </ul>
+          <div class="info-item">
+            <span class="label">星座</span>
+            <span class="value">双子座</span>
+          </div>
+          <div class="info-item">
+            <span class="label">求职意向</span>
+            <span class="value">信息系统技术·信息管理岗</span>
+          </div>
+          <div class="info-item">
+            <span class="label">邮箱</span>
+            <span class="value">
+              <a href="mailto:zhangyy-campus@edu.example.com">zhangyy-campus@edu.example.com</a>
+            </span>
           </div>
         </div>
-      </div>
-    </section>
-
-    <section id="projects" class="py-5 bg-body" aria-labelledby="projects-title">
-      <div class="container">
-        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-4">
-          <h2 id="projects-title" class="fw-semibold mb-3 mb-md-0">精选项目</h2>
-          <p class="text-secondary mb-0">聚焦真实业务场景的端到端解决方案。</p>
-        </div>
-        <div class="row g-4">
-          <article class="col-md-4">
-            <div class="card project-card h-100">
-              <img src="https://picsum.photos/seed/project1/600/400" class="card-img-top" alt="智慧校园平台" loading="lazy" width="600" height="400" />
-              <div class="card-body">
-                <h3 class="card-title h5">智慧校园平台</h3>
-                <p class="card-text text-secondary">面向高校的教务与活动统一门户，支持多端访问与离线缓存。</p>
-                <div class="mb-3">
-                  <span class="badge text-bg-light text-uppercase">React</span>
-                  <span class="badge text-bg-light text-uppercase">PWA</span>
-                </div>
-                <a class="btn btn-outline-primary btn-sm" href="#" role="button">查看</a>
-              </div>
-            </div>
-          </article>
-          <article class="col-md-4">
-            <div class="card project-card h-100">
-              <img src="https://picsum.photos/seed/project2/600/400" class="card-img-top" alt="金融数据分析平台" loading="lazy" width="600" height="400" />
-              <div class="card-body">
-                <h3 class="card-title h5">金融分析仪表盘</h3>
-                <p class="card-text text-secondary">实时展示风控指标，集成权限管理与动态报表导出。</p>
-                <div class="mb-3">
-                  <span class="badge text-bg-light text-uppercase">Vue</span>
-                  <span class="badge text-bg-light text-uppercase">ECharts</span>
-                </div>
-                <a class="btn btn-outline-primary btn-sm" href="#" role="button">查看</a>
-              </div>
-            </div>
-          </article>
-          <article class="col-md-4">
-            <div class="card project-card h-100">
-              <img src="https://picsum.photos/seed/project3/600/400" class="card-img-top" alt="跨境电商平台" loading="lazy" width="600" height="400" />
-              <div class="card-body">
-                <h3 class="card-title h5">跨境电商平台</h3>
-                <p class="card-text text-secondary">集成多语言与多币种的购物体验，优化 SEO 与加载速度。</p>
-                <div class="mb-3">
-                  <span class="badge text-bg-light text-uppercase">Next.js</span>
-                  <span class="badge text-bg-light text-uppercase">i18n</span>
-                </div>
-                <a class="btn btn-outline-primary btn-sm" href="#" role="button">查看</a>
-              </div>
-            </div>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section id="contact" class="py-5" aria-labelledby="contact-title">
-      <div class="container">
-        <div class="row g-4">
-          <div class="col-lg-5">
-            <h2 id="contact-title" class="fw-semibold">保持联系</h2>
-            <p class="text-secondary">欢迎交流前端工程、团队协作或开源项目。期待与优秀团队共同创造价值。</p>
-            <div class="alert alert-success d-none" role="status" id="formAlert">消息已收到，将尽快回复！</div>
-          </div>
-          <div class="col-lg-7">
-            <form id="contactForm" novalidate>
-              <div class="mb-3">
-                <label for="name" class="form-label">姓名</label>
-                <input type="text" class="form-control" id="name" name="name" required aria-required="true" />
-                <div class="invalid-feedback">请填写姓名。</div>
-              </div>
-              <div class="mb-3">
-                <label for="email" class="form-label">邮箱</label>
-                <input type="email" class="form-control" id="email" name="email" required aria-required="true" />
-                <div class="invalid-feedback">请输入有效邮箱地址。</div>
-              </div>
-              <div class="mb-3">
-                <label for="message" class="form-label">消息</label>
-                <textarea class="form-control" id="message" name="message" rows="4" required aria-required="true"></textarea>
-                <div class="invalid-feedback">请填写留言内容。</div>
-              </div>
-              <div class="form-check mb-3">
-                <input class="form-check-input" type="checkbox" value="agree" id="consent" required aria-required="true" />
-                <label class="form-check-label" for="consent">我已阅读并同意隐私政策。</label>
-                <div class="invalid-feedback d-block">提交前需同意条款。</div>
-              </div>
-              <button type="submit" class="btn btn-primary">发送消息</button>
-            </form>
-          </div>
-        </div>
-      </div>
-    </section>
-  </main>
-
-  <footer class="py-4 bg-dark text-white" aria-label="页脚">
-    <div class="container d-flex flex-column flex-md-row align-items-center justify-content-between gap-3">
-      <p class="mb-0">© <span id="currentYear"></span> Li Lei. All rights reserved.</p>
-      <div class="d-flex align-items-center gap-3">
-        <a class="text-white" href="#" aria-label="GitHub" rel="noopener noreferrer"><i class="bi bi-github"></i></a>
-        <a class="text-white" href="#" aria-label="LinkedIn" rel="noopener noreferrer"><i class="bi bi-linkedin"></i></a>
-        <a class="text-white" href="#top" aria-label="返回顶部" id="backToTop"><i class="bi bi-arrow-up-circle"></i></a>
-      </div>
+      </section>
     </div>
-  </footer>
-
-  <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-3fnmF2kRxpav0/6xCwW+UB0pJ+qS0bM6pJ9mG0kCKJw=" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-  <script src="script.js"></script>
+  </div>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,97 +1,209 @@
 :root {
-  --primary: #5566ff;
-  --dark: #0f172a;
-  --light-bg: #f6f7fb;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color-scheme: light;
+  --bg-gradient-start: #f1f5ff;
+  --bg-gradient-end: #e8f6ff;
+  --card-shadow: 0 20px 45px rgba(41, 72, 152, 0.12);
+  --card-radius: 28px;
+  --primary-text: #1f2a44;
+  --muted-text: #5f6b8a;
+  font-family: 'Noto Sans SC', 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
-  font-family: inherit;
-  color: #1f2937;
-  background-color: #ffffff;
-  scroll-behavior: smooth;
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  background: linear-gradient(160deg, var(--bg-gradient-start), var(--bg-gradient-end));
+  color: var(--primary-text);
+  line-height: 1.75;
 }
 
-.navbar {
-  transition: background-color 0.3s ease;
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
-.navbar .nav-link {
-  font-weight: 500;
+a:hover {
+  text-decoration: underline;
 }
 
-.navbar .nav-link:focus-visible,
-.navbar .nav-link:hover {
-  color: var(--primary);
+a:focus-visible {
+  outline: 2px solid rgba(107, 132, 214, 0.7);
+  outline-offset: 3px;
+  border-radius: 6px;
 }
 
-.backdrop-blur {
+h1,
+h2,
+dl {
+  margin: 0;
+}
+
+.resume-wrapper {
+  width: min(1100px, 100%);
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 32px;
+}
+
+.profile-card {
+  background: #ffffff;
+  border-radius: var(--card-radius);
+  padding: 32px 28px;
+  box-shadow: var(--card-shadow);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.profile-card .avatar {
+  width: 200px;
+  height: 200px;
+  border-radius: 24px;
+  object-fit: cover;
+  margin-bottom: 24px;
+  box-shadow: 0 12px 30px rgba(23, 40, 90, 0.18);
+}
+
+.profile-card h1 {
+  font-size: 1.85rem;
+  letter-spacing: 0.02em;
+  margin-bottom: 4px;
+}
+
+.profile-card .subtitle {
+  font-size: 1rem;
+  color: var(--muted-text);
+  margin-bottom: 26px;
+}
+
+.profile-data {
+  width: 100%;
+  display: grid;
+  gap: 16px;
+}
+
+.data-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #f5f8ff, #edf3ff);
+  box-shadow: inset 0 0 0 1px rgba(113, 136, 206, 0.12);
+}
+
+.data-row dt {
+  font-weight: 600;
+  color: #3a4b7a;
+}
+
+.data-row dd {
+  margin: 0;
+  font-weight: 600;
+  color: #111a34;
+}
+
+.detail-column {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.detail-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--card-radius);
+  padding: 32px 36px;
+  box-shadow: var(--card-shadow);
   backdrop-filter: blur(8px);
 }
 
-main {
-  background-color: var(--light-bg);
+.detail-card h2 {
+  font-size: 1.65rem;
+  margin-bottom: 16px;
 }
 
-section {
-  scroll-margin-top: 5rem;
+.detail-card p {
+  margin: 0 0 12px;
+  color: var(--muted-text);
+  font-size: 1.05rem;
 }
 
-.profile-photo {
-  object-fit: cover;
+.detail-card p:last-child {
+  margin-bottom: 0;
 }
 
-.skill-list .badge {
-  font-size: 0.95rem;
-  padding: 0.65rem 1rem;
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
 }
 
-.project-card {
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+.info-item {
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(135deg, #eef4ff, #f8faff);
+  border-radius: 18px;
+  padding: 18px 20px;
+  box-shadow: inset 0 0 0 1px rgba(104, 126, 204, 0.12);
 }
 
-.project-card:hover,
-.project-card:focus-within {
-  transform: translateY(-4px);
-  box-shadow: 0 0.75rem 2rem rgba(15, 23, 42, 0.12);
+.info-item .label {
+  font-size: 0.9rem;
+  color: #6072a1;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
 }
 
-.project-card .btn {
-  transition: transform 0.3s ease;
+.info-item .value {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #223256;
+  word-break: break-word;
 }
 
-.project-card .btn:hover,
-.project-card .btn:focus-visible {
-  transform: translateY(-1px);
+.info-item .value a {
+  color: inherit;
 }
 
-#contactForm .form-control:focus,
-#contactForm .form-check-input:focus {
-  border-color: var(--primary);
-  box-shadow: 0 0 0 0.25rem rgba(85, 102, 255, 0.15);
-}
-
-footer a {
-  font-size: 1.25rem;
-}
-
-footer a:focus-visible {
-  outline: 2px solid #fff;
-  outline-offset: 2px;
-}
-
-@media (max-width: 767.98px) {
-  main {
-    background-color: #ffffff;
+@media (max-width: 1024px) {
+  body {
+    padding: 40px 20px;
   }
 
-  section {
-    padding-top: 3.5rem !important;
-    padding-bottom: 3.5rem !important;
+  .resume-wrapper {
+    grid-template-columns: 1fr;
   }
 
-  .skill-list .badge {
-    display: inline-flex;
-    margin-bottom: 0.5rem;
+  .profile-card {
+    text-align: left;
+    align-items: flex-start;
+  }
+
+  .profile-card .avatar {
+    align-self: center;
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 32px 16px;
+  }
+
+  .detail-card {
+    padding: 28px 24px;
+  }
+
+  .info-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- replace the previous multi-section site with a two-column resume that mirrors the provided reference content
- restyle the page with new typography, gradient background, and card-based panels for profile, summary, and personal details

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e6a7ed7488832ca89836e7e49b986c