### PR TITLE
Rebuild About section per provided layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>李雷 · 前端工程师</title>
+  <title>张媛媛 · 个人主页</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
@@ -12,10 +12,10 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="fixed-top shadow-sm bg-body-tertiary bg-opacity-75 backdrop-blur">
-    <nav class="navbar navbar-expand-lg navbar-light" aria-label="Primary navigation">
+  <header class="fixed-top standout-header">
+    <nav class="navbar navbar-expand-lg navbar-dark" aria-label="Primary navigation">
       <div class="container">
-        <a class="navbar-brand fw-semibold" href="#top">Li Lei</a>
+        <a class="navbar-brand fw-semibold text-uppercase" href="#top">张媛媛</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#primaryNav" aria-controls="primaryNav" aria-expanded="false" aria-label="切换导航">
           <span class="navbar-toggler-icon"></span>
         </button>
@@ -34,18 +34,35 @@
   <main id="top" class="pt-5">
     <section id="about" class="py-5" aria-labelledby="about-title">
       <div class="container">
-        <div class="row align-items-center g-4">
-          <div class="col-md-4 text-center">
-            <figure class="m-0">
-              <img src="https://picsum.photos/320" alt="李雷头像" class="img-fluid rounded-circle shadow-sm profile-photo" loading="lazy" width="320" height="320" />
-              <figcaption class="visually-hidden">前端工程师李雷的头像</figcaption>
-            </figure>
-          </div>
-          <div class="col-md-8">
-            <h1 id="about-title" class="fw-bold mb-3">李雷 · 前端工程师</h1>
-            <p class="lead text-secondary">热爱简洁代码与优雅体验的全栈倾向前端开发者。</p>
-            <p>专注于构建性能优、可维护的 Web 应用，擅长将设计转化为灵活的交互界面，并持续关注可访问性与工程效率。</p>
-            <a class="btn btn-primary mt-3" href="#" role="button">下载简历</a>
+        <div class="about-surface p-4 p-lg-5">
+          <div class="row g-4 align-items-stretch">
+            <div class="col-lg-5">
+              <article class="summary-card h-100" aria-labelledby="about-title">
+                <div class="summary-visual" role="presentation">
+                  <img src="https://picsum.photos/seed/intro-cover/720/280" alt="山脉与湖泊的风景图" loading="lazy" width="720" height="280" />
+                </div>
+                <div class="summary-body">
+                  <h1 id="about-title" class="summary-title">个人简介</h1>
+                  <p>湖北中医药大学信息工程学院在读女生，专注于信息系统的规划与实现。</p>
+                  <p>热爱将业务流程与技术结合，熟悉 C#、Web 前端基础开发技能，在项目中注重数据安全与使用体验的平衡。</p>
+                </div>
+              </article>
+            </div>
+            <div class="col-lg-7">
+              <article class="info-card h-100" aria-label="张媛媛的个人信息">
+                <h2 class="info-card-title">个人信息</h2>
+                <ul class="list-unstyled info-list mb-0">
+                  <li class="info-list-item"><span class="info-term">姓名</span><span class="info-desc">张媛媛</span></li>
+                  <li class="info-list-item"><span class="info-term">学号</span><span class="info-desc">2023307012100</span></li>
+                  <li class="info-list-item"><span class="info-term">院系</span><span class="info-desc">信息工程学院</span></li>
+                  <li class="info-list-item"><span class="info-term">专业</span><span class="info-desc">信息管理与信息系统</span></li>
+                  <li class="info-list-item"><span class="info-term">毕业年份</span><span class="info-desc">2027年</span></li>
+                  <li class="info-list-item"><span class="info-term">籍贯</span><span class="info-desc">贵州铜仁</span></li>
+                  <li class="info-list-item"><span class="info-term">星座</span><span class="info-desc">未知</span></li>
+                  <li class="info-list-item"><span class="info-term">邮箱</span><a class="info-link" href="mailto:zhangyy-campus@edu.example.com">zhangyy-campus@edu.example.com</a></li>
+                </ul>
+              </article>
+            </div>
           </div>
         </div>
       </div>
@@ -106,9 +123,6 @@
               <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">JavaScript</span></li>
               <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">Bootstrap</span></li>
               <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">jQuery</span></li>
-              <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">Git</span></li>
-              <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">REST API</span></li>
-              <li class="list-inline-item"><span class="badge rounded-pill text-bg-primary">Accessibility</span></li>
             </ul>
           </div>
         </div>
@@ -118,19 +132,19 @@
     <section id="projects" class="py-5 bg-body" aria-labelledby="projects-title">
       <div class="container">
         <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-4">
-          <h2 id="projects-title" class="fw-semibold mb-3 mb-md-0">精选项目</h2>
-          <p class="text-secondary mb-0">聚焦真实业务场景的端到端解决方案。</p>
+          <h2 id="projects-title" class="fw-semibold mb-3 mb-md-0">项目展示</h2>
+          <p class="text-secondary mb-0">围绕教学管理与校园信息化的实践成果。</p>
         </div>
         <div class="row g-4">
           <article class="col-md-4">
             <div class="card project-card h-100">
-              <img src="https://picsum.photos/seed/project1/600/400" class="card-img-top" alt="智慧校园平台" loading="lazy" width="600" height="400" />
+              <img src="https://picsum.photos/seed/teaching/600/400" class="card-img-top" alt="教学管理系统界面示意" loading="lazy" width="600" height="400" />
               <div class="card-body">
-                <h3 class="card-title h5">智慧校园平台</h3>
-                <p class="card-text text-secondary">面向高校的教务与活动统一门户，支持多端访问与离线缓存。</p>
+                <h3 class="card-title h5">教学管理</h3>
+                <p class="card-text text-secondary">运用 C# 语言编写出了一个教学管理系统，包括学生成绩修改与录入，学生信息管理与修改，学生信息的存储，学生课程录入与修改。</p>
                 <div class="mb-3">
-                  <span class="badge text-bg-light text-uppercase">React</span>
-                  <span class="badge text-bg-light text-uppercase">PWA</span>
+                  <span class="badge text-bg-light text-uppercase">C#</span>
+                  <span class="badge text-bg-light text-uppercase">WinForms</span>
                 </div>
                 <a class="btn btn-outline-primary btn-sm" href="#" role="button">查看</a>
               </div>
@@ -138,13 +152,13 @@
           </article>
           <article class="col-md-4">
             <div class="card project-card h-100">
-              <img src="https://picsum.photos/seed/project2/600/400" class="card-img-top" alt="金融数据分析平台" loading="lazy" width="600" height="400" />
+              <img src="https://picsum.photos/seed/bookshop/600/400" class="card-img-top" alt="二手书网站页面预览" loading="lazy" width="600" height="400" />
               <div class="card-body">
-                <h3 class="card-title h5">金融分析仪表盘</h3>
-                <p class="card-text text-secondary">实时展示风控指标，集成权限管理与动态报表导出。</p>
+                <h3 class="card-title h5">二手书网站</h3>
+                <p class="card-text text-secondary">构建面向校园的二手书交易平台，支持分类检索、价格智能推荐与留言交流，帮助学生高效完成教材流转。</p>
                 <div class="mb-3">
-                  <span class="badge text-bg-light text-uppercase">Vue</span>
-                  <span class="badge text-bg-light text-uppercase">ECharts</span>
+                  <span class="badge text-bg-light text-uppercase">Laravel</span>
+                  <span class="badge text-bg-light text-uppercase">MySQL</span>
                 </div>
                 <a class="btn btn-outline-primary btn-sm" href="#" role="button">查看</a>
               </div>
@@ -152,13 +166,13 @@
           </article>
           <article class="col-md-4">
             <div class="card project-card h-100">
-              <img src="https://picsum.photos/seed/project3/600/400" class="card-img-top" alt="跨境电商平台" loading="lazy" width="600" height="400" />
+              <img src="https://picsum.photos/seed/hospital/600/400" class="card-img-top" alt="医院库存管理系统界面示意" loading="lazy" width="600" height="400" />
               <div class="card-body">
-                <h3 class="card-title h5">跨境电商平台</h3>
-                <p class="card-text text-secondary">集成多语言与多币种的购物体验，优化 SEO 与加载速度。</p>
+                <h3 class="card-title h5">医院库存管理</h3>
+                <p class="card-text text-secondary">以湖北中医药大学附属医院的库存管理为模型，编写了库存管理后台，支持药品入库出库、库存预警与科室领用流程跟踪。</p>
                 <div class="mb-3">
-                  <span class="badge text-bg-light text-uppercase">Next.js</span>
-                  <span class="badge text-bg-light text-uppercase">i18n</span>
+                  <span class="badge text-bg-light text-uppercase">.NET</span>
+                  <span class="badge text-bg-light text-uppercase">SQL Server</span>
                 </div>
                 <a class="btn btn-outline-primary btn-sm" href="#" role="button">查看</a>
               </div>
@@ -173,7 +187,7 @@
         <div class="row g-4">
           <div class="col-lg-5">
             <h2 id="contact-title" class="fw-semibold">保持联系</h2>
-            <p class="text-secondary">欢迎交流前端工程、团队协作或开源项目。期待与优秀团队共同创造价值。</p>
+            <p class="text-secondary">欢迎交流信息管理、校园系统建设或高校数字化转型相关合作，共同探索更多可能性。</p>
             <div class="alert alert-success d-none" role="status" id="formAlert">消息已收到，将尽快回复！</div>
           </div>
           <div class="col-lg-7">
@@ -208,7 +222,7 @@
 
   <footer class="py-4 bg-dark text-white" aria-label="页脚">
     <div class="container d-flex flex-column flex-md-row align-items-center justify-content-between gap-3">
-      <p class="mb-0">© <span id="currentYear"></span> Li Lei. All rights reserved.</p>
+      <p class="mb-0">© <span id="currentYear"></span> 张媛媛. All rights reserved.</p>
       <div class="d-flex align-items-center gap-3">
         <a class="text-white" href="#" aria-label="GitHub" rel="noopener noreferrer"><i class="bi bi-github"></i></a>
         <a class="text-white" href="#" aria-label="LinkedIn" rel="noopener noreferrer"><i class="bi bi-linkedin"></i></a>

--- a/styles.css
+++ b/styles.css
@@ -12,21 +12,30 @@ body {
   scroll-behavior: smooth;
 }
 
+.standout-header {
+  background: linear-gradient(90deg, rgba(85, 102, 255, 0.95), rgba(37, 99, 235, 0.95));
+  box-shadow: 0 0.75rem 1.75rem rgba(15, 23, 42, 0.2);
+}
+
 .navbar {
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.navbar .navbar-brand {
+  letter-spacing: 0.12em;
 }
 
 .navbar .nav-link {
-  font-weight: 500;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+  letter-spacing: 0.05em;
 }
 
 .navbar .nav-link:focus-visible,
-.navbar .nav-link:hover {
-  color: var(--primary);
-}
-
-.backdrop-blur {
-  backdrop-filter: blur(8px);
+.navbar .nav-link:hover,
+.navbar .nav-link.active {
+  color: #ffffff;
 }
 
 main {
@@ -37,6 +46,100 @@ section {
   scroll-margin-top: 5rem;
 }
 
+#about {
+  background: linear-gradient(135deg, #eef2ff 0%, #f8fafc 100%);
+}
+
+.about-surface {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 2rem;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(6px);
+}
+
+.summary-card {
+  background-color: #ffffff;
+  border-radius: 1.75rem;
+  box-shadow: 0 1rem 2.5rem rgba(15, 23, 42, 0.12);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.summary-visual img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+
+.summary-body {
+  padding: 2rem;
+}
+
+.summary-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 1.25rem;
+}
+
+.summary-body p {
+  color: #475569;
+  line-height: 1.75;
+  margin-bottom: 1rem;
+}
+
+.info-card {
+  background-color: #ffffff;
+  border-radius: 1.75rem;
+  box-shadow: 0 1rem 2.5rem rgba(15, 23, 42, 0.12);
+  padding: 2.5rem 2.75rem;
+}
+
+.info-card-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+}
+
+.info-list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.info-list-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.info-list-item:first-child {
+  padding-top: 0;
+}
+
+.info-term {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.info-desc,
+.info-link {
+  color: #475569;
+  font-weight: 500;
+}
+
+.info-link {
+  text-decoration: none;
+}
+
+.info-link:focus-visible,
+.info-link:hover {
+  color: var(--primary);
+  text-decoration: underline;
+}
+
 .profile-photo {
   object-fit: cover;
 }
@@ -44,6 +147,29 @@ section {
 .skill-list .badge {
   font-size: 0.95rem;
   padding: 0.65rem 1rem;
+}
+
+.info-tile {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.08);
+  height: 100%;
+}
+
+.info-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.info-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1f2937;
 }
 
 .project-card {
@@ -88,6 +214,19 @@ footer a:focus-visible {
   section {
     padding-top: 3.5rem !important;
     padding-bottom: 3.5rem !important;
+  }
+
+  .about-surface {
+    padding: 2.25rem !important;
+  }
+
+  .info-card {
+    padding: 2rem;
+  }
+
+  .info-list-item {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .skill-list .badge {


### PR DESCRIPTION
## Summary
- restructure the About section into dual-card layout with a photo banner and textual summary matching the provided screenshot
- replace the badge grid with a concise personal information list containing the requested details
- add gradient and card styling utilities to support the updated presentation while maintaining responsiveness

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e6a7ed7488832ca89836e7e49b986c